### PR TITLE
Upgrade to python 3.13 and other changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@
 # https://github.com/kaouthia
 
 # Use a minimal Python base image (adjust version as needed)
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-bookworm
+# Evaluate the need for NVidia specific CUDA images
+# @See https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda?version=13.1.1-runtime-ubuntu24.04
 
 # Allow passing in your host UID/GID (defaults 1000:1000)
 ARG UID=1000
@@ -26,6 +28,9 @@ RUN apt-get update \
       fontconfig \
  && rm -rf /var/lib/apt/lists/*
 
+# Upgrade pip
+RUN pip install --upgrade pip
+
 # Copy and enable the startup script
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -38,6 +43,10 @@ ENV PATH=/home/appuser/.local/bin:$PATH
 
 # Set the working directory
 WORKDIR /app
+
+# Force cu130 installation to be run before the ComfyUI pip install -r requirements.txt
+# https://github.com/comfy-org/ComfyUI?tab=readme-ov-file#nvidia
+RUN pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu130
 
 # Clone the ComfyUI repository (replace URL with the official repo)
 RUN git clone https://github.com/comfyanonymous/ComfyUI.git

--- a/clean_rebuild.bat
+++ b/clean_rebuild.bat
@@ -1,0 +1,7 @@
+docker compose down
+docker compose rm -f
+docker image rm comfyui:latest
+docker builder prune -af
+docker compose build --no-cache
+docker compose up -d
+pause

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,18 +11,19 @@ services:
     ports:
       - "8188:8188"
     volumes:
-      # persist your models, output, and settings:
-      - c:/home/user/comfyui/models:/app/ComfyUI/models
+      # persist your models:
+      - c:/home/user/comfyui/models:/app/ComfyUI/models:rw
 
-      # persist your output images:
-      - c:/home/user/comfyui/output:/app/ComfyUI/output
+      # load your input content:
+      - c:/home/user/comfyui/input:/app/ComfyUI/input:rw
+
+      # persist your output content:
+      - c:/home/user/comfyui/output:/app/ComfyUI/output:rw
       
-      # persist all your settings & extra nodes:
-      - c:/home/user/comfyui/settings:/app/ComfyUI/user/default:rw
-
-      # persist just your saved flows (overrides the workflows/ in default):
-      - c:/home/user/comfyui/flows:/app/ComfyUI/user/default/workflows:rw
+      # persist user settings:
+      - c:/home/user/comfyui/user:/app/ComfyUI/user:rw
     
+    # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html
     runtime: nvidia
     environment:
       - NVIDIA_VISIBLE_DEVICES=all

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,13 +8,14 @@ set -e
 
 # --- Force ComfyUI-Manager config (uv off, no file logging, safe DB) ---
 # Make sure user dirs exist and are writable (handles Windows bind mounts)
-mkdir -p /app/ComfyUI/user /app/ComfyUI/user/default
+mkdir -p /app/ComfyUI/user /app/ComfyUI/user/default /app/ComfyUI/user/__manager
 chown -R "$(id -u)":"$(id -g)" /app/ComfyUI/user || true
 chmod -R u+rwX /app/ComfyUI/user || true
 
-CFG_DIR="/app/ComfyUI/user/default/ComfyUI-Manager"
+CFG_DIR="/app/ComfyUI/user/__manager"
 CFG_FILE="$CFG_DIR/config.ini"
-DB_DIR="$CFG_DIR"
+
+DB_DIR="/app/ComfyUI/user/default"
 DB_PATH="${DB_DIR}/manager.db"
 SQLITE_URL="sqlite:////${DB_PATH}"
 
@@ -28,29 +29,11 @@ use_uv = False
 file_logging = False
 db_mode = cache
 database_url = ${SQLITE_URL}
+security_level = weak
+network_mode = public
+always_lazy_install = False
+bypass_ssl = True
 EOF
-else
-  echo "↳ Updating ComfyUI-Manager config.ini (uv OFF, no file logging, DB cache)"
-  # use_uv = False
-  grep -q '^use_uv' "$CFG_FILE" \
-    && sed -i 's/^use_uv.*/use_uv = False/' "$CFG_FILE" \
-    || printf '\nuse_uv = False\n' >> "$CFG_FILE"
-
-  # file_logging = False (and drop any existing log_path line)
-  grep -q '^file_logging' "$CFG_FILE" \
-    && sed -i 's/^file_logging.*/file_logging = False/' "$CFG_FILE" \
-    || printf '\nfile_logging = False\n' >> "$CFG_FILE"
-  sed -i '/^log_path[[:space:]=]/d' "$CFG_FILE" || true
-
-  # db_mode = cache (prevents file DB usage)
-  grep -q '^db_mode' "$CFG_FILE" \
-    && sed -i 's/^db_mode.*/db_mode = cache/' "$CFG_FILE" \
-    || printf '\ndb_mode = cache\n' >> "$CFG_FILE"
-
-  # Provide a safe DB URL anyway (future-proof if Manager flips off cache)
-  grep -q '^database_url' "$CFG_FILE" \
-    && sed -i "s|^database_url.*|database_url = ${SQLITE_URL}|" "$CFG_FILE" \
-    || printf "database_url = ${SQLITE_URL}\n" >> "$CFG_FILE"
 fi
 
 


### PR DESCRIPTION
I recently tried this ComfyUI Docker setup and found some small adjustments needed to bring it up to date:

- Latest ComfyUI recommends Python 3.13
https://docs.comfy.org/installation/system_requirements#python-version

- I hate when pip is asking to be upgraded every time we use it :-)

- The CUDA 130 is recommended as well, I know it depends on the hardware but not having it explicitly installed, I was having cu128 installed automatically and a WARNING in ComfyUI logs telling me it's incorrect.

- I got some errors trying to install custom nodes and it was about security issues. To allow it I had to use security_level = weak in the config.ini file. However I struggled to understand why it was not taking effect and the answer was that in the latest ComfyUI version, the /user/__manager/ folder is used to store this file. Making the change to not use /user/default/ made it work.
However, I got some read/write access on the binding folders so I decided to allow read/write on the "user" folder altogether to avoid this.
The other config.ini changes are purely personal, and the update of the file didn't seem relevant so I removed it.

This PR is "inspirational" and doesn't have to be merged as-is but you may want to test it and get "the best of it"

Best regards and thanks for the amazing job on the repo.