### PR TITLE
Fix container permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,17 @@ RUN apt-get update \
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# make ~/.local/bin available on the PATH so scripts like tqdm, torchrun, etc. are found
+ENV PATH=/home/appuser/.local/bin:$PATH
+
 # Set the working directory
 WORKDIR /app
+
+# Ensure the non-root user can write here
+RUN chown -R appuser:appuser /app
+
+# Switch to non-root user
+USER $UID:$GID
 
 # Clone the ComfyUI repository (replace URL with the official repo)
 RUN git clone https://github.com/comfyanonymous/ComfyUI.git
@@ -44,15 +53,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # (Optional) Clean up pip cache to reduce image size
 RUN pip cache purge
-
-# Fix ownership once at the end
-RUN chown -R appuser:appuser /app
-
-# Switch to non-root user
-USER $UID:$GID
-
-# make ~/.local/bin available on the PATH so scripts like tqdm, torchrun, etc. are found
-ENV PATH=/home/appuser/.local/bin:$PATH
 
 # Expose the port that ComfyUI will use (change if needed)
 EXPOSE 8188

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,6 @@ RUN apt-get update \
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Switch to non-root user
-USER $UID:$GID
-
-# make ~/.local/bin available on the PATH so scripts like tqdm, torchrun, etc. are found
-ENV PATH=/home/appuser/.local/bin:$PATH
-
 # Set the working directory
 WORKDIR /app
 
@@ -50,6 +44,15 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # (Optional) Clean up pip cache to reduce image size
 RUN pip cache purge
+
+# Fix ownership once at the end
+RUN chown -R appuser:appuser /app
+
+# Switch to non-root user
+USER $UID:$GID
+
+# make ~/.local/bin available on the PATH so scripts like tqdm, torchrun, etc. are found
+ENV PATH=/home/appuser/.local/bin:$PATH
 
 # Expose the port that ComfyUI will use (change if needed)
 EXPOSE 8188


### PR DESCRIPTION
Fixed an issue with permissions when building container. (Closes #14 )

## Problem
Dockerfile switches to a non-root user prior to cloning the ComfyUI repository
Since `/app` is owned by root, this causes:
`fatal: could not create work tree dir 'ComfyUI': Permission denied`

## Fix
added `chown` prior to cloning the repository, allowing `appuser` write access to `/app`

## Tests
- `git clone` completes without errors
- Container builds correctly
- ComfyUI runs as expected